### PR TITLE
Change default `CKA_MODIFIABLE` value to true

### DIFF
--- a/pkg/pkcs11client/keyconfig.go
+++ b/pkg/pkcs11client/keyconfig.go
@@ -188,7 +188,7 @@ func (kp *KeyConfigKeyPairTemplate) GenDefaultKeySecurityTemplate() {
 		IsPrivate:          true,
 		IsSensitive:        true,
 		IsAlwaysSensitive:  true,
-		IsModifiable:       false,
+		IsModifiable:       true,
 		IsExtractable:      false,
 		IsNeverExtractable: true,
 	}


### PR DESCRIPTION
Change default `CKA_MODIFIABLE` value to true to match PKCS11 [documentation](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/errata01/os/pkcs11-base-v2.40-errata01-os-complete.html).
Issue discovered when testing it with AWS CloudHSM https://github.com/mode51software/vaultplugin-hsmpki/issues/25